### PR TITLE
Added XR Battery firmware version

### DIFF
--- a/Known Firmware Versions.md
+++ b/Known Firmware Versions.md
@@ -17,6 +17,7 @@ Firmware updates that I've seen or found sources for. Have a Screenshot/Reddit P
 | ------- | ------------ | ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
 | 2.5.1   |              | **Firmware v2.5.1 for B2XR**<br>Minor bugfixes and improvements | Changes (improves?) balancing algorithm, per a [Reddit Post](https://old.reddit.com/r/boostedboards/comments/domk54/boosted\_xr\_battery\_not\_charging\_to\_100\_update\_w/) . | Self   |
 | 2.1.5   |              |                                                             |                                                                                                                                                                              | Self   |
+| 2.1.2   |              |                                                             |                                                                                                                                                                              | LightBlue   |
 
 
 ### SR Batteries


### PR DESCRIPTION
I checked my board version and xr battery version today using the LightBlue app on my phone. Board version v2.1.9 and xr battery 2.1.2.