### PR TITLE
Add SR Battery version 1.6.3

### DIFF
--- a/Known Firmware Versions.md
+++ b/Known Firmware Versions.md
@@ -25,4 +25,5 @@ I'm not sure that OTA firmware updates were ever released for SR batteries, or i
 
 | Version | Source |
 | ------- | ------ |
+| 1.6.3   | [willbicks](https://i.imgur.com/mGBtIMU.jpg) |
 | 1.4.1   | Self   |


### PR DESCRIPTION
In playing with my (new to me) Boosted Mini S, I discovered I have a battery firmware version that is newer than the only one you have listed for the SR packs. Here's a pull request that adds the firmware version I have. 

Thanks for all your great research and information sharing!